### PR TITLE
Fix suffix check to prevent autoloading classes with side effects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "TestApp\\": "tests/integration/src/",
             "Tests\\ConsoleApp\\": "tests/unit/"
         }
     },

--- a/src/ClassmapCommandProvider.php
+++ b/src/ClassmapCommandProvider.php
@@ -49,8 +49,8 @@ final class ClassmapCommandProvider implements IteratorAggregate, CommandProvide
             ->cast($this->helper->realpath(...))
             ->filter($this->helper->isNotVendoredDependency(...))
             ->keys()
-            ->filter($this->helper->isCommandSubclass(...))
             ->filter($this->helper->hasCommandSuffix(...))
+            ->filter($this->helper->isCommandSubclass(...))
             ->cast($this->helper->newCommand(...))
             ->filter();
     }

--- a/src/CommandProviderDiscovery.php
+++ b/src/CommandProviderDiscovery.php
@@ -50,8 +50,8 @@ final class CommandProviderDiscovery implements IteratorAggregate, CommandProvid
             ->filter($this->helper->isNotVendoredDependency(...))
             ->keys()
             ->filter($this->helper->isNotOurNamespace(...))
-            ->filter($this->helper->isCommandProviderSubclass(...))
             ->filter($this->helper->hasCommandProviderSuffix(...))
+            ->filter($this->helper->isCommandProviderSubclass(...))
             ->cast($this->helper->newCommandProvider(...))
             ->unpack();
     }

--- a/tests/integration/src/WithSideEffects.php
+++ b/tests/integration/src/WithSideEffects.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright 2025 Alexey Kopytko <alexey@kopytko.com>
  *

--- a/tests/integration/src/WithSideEffects.php
+++ b/tests/integration/src/WithSideEffects.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Copyright 2025 Alexey Kopytko <alexey@kopytko.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace TestApp;
+
+use RuntimeException;
+
+class WithSideEffects {}
+
+throw new RuntimeException("This class should not be loaded");

--- a/tests/unit/ClassmapCommandProviderTest.php
+++ b/tests/unit/ClassmapCommandProviderTest.php
@@ -55,12 +55,12 @@ final class ClassmapCommandProviderTest extends TestCase
             ->willReturn(true);
 
         $helper->expects($this->once())
-            ->method('isCommandSubclass')
+            ->method('hasCommandSuffix')
             ->with(HelloCommand::class)
             ->willReturn(true);
 
         $helper->expects($this->once())
-            ->method('hasCommandSuffix')
+            ->method('isCommandSubclass')
             ->with(HelloCommand::class)
             ->willReturn(true);
 

--- a/tests/unit/CommandProviderDiscoveryTest.php
+++ b/tests/unit/CommandProviderDiscoveryTest.php
@@ -61,12 +61,12 @@ final class CommandProviderDiscoveryTest extends TestCase
             ->willReturn(true);
 
         $helper->expects($this->once())
-            ->method('isCommandProviderSubclass')
+            ->method('hasCommandProviderSuffix')
             ->with(TestCommandProvider::class)
             ->willReturn(true);
 
         $helper->expects($this->once())
-            ->method('hasCommandProviderSuffix')
+            ->method('isCommandProviderSubclass')
             ->with(TestCommandProvider::class)
             ->willReturn(true);
 


### PR DESCRIPTION
Check class name suffix before instanceof to avoid triggering autoload for classes that don't match our naming convention. This prevents classes with side effects from being loaded during discovery.

Added WithSideEffects test class to verify the fix works correctly.